### PR TITLE
Don't transform all modules to commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
 			'@babel/preset-env',
 			{
 				useBuiltIns: false,
-				modules: 'commonjs',
+				modules: 'auto',
 			},
 		],
 	],


### PR DESCRIPTION
Enforcing modules transformation to commonjs does block webpack from using code splitting. 

From https://babeljs.io/docs/en/babel-preset-env:
> Setting this to false will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. **If you are using a bundler with Babel, the default modules: "auto" is always preferred.
> modules: "auto"**
> 
> By default @babel/preset-env uses caller data to determine whether ES modules and module features (e.g. import()) should be transformed. Generally caller data will be specified in the bundler plugins (e.g. babel-loader, @rollup/plugin-babel) and thus it is not recommended to pass caller data yourself -- The passed caller may overwrite the one from bundler plugins and in the future you may get suboptimal results if bundlers supports new module features.

Encountered in https://github.com/nextcloud/text/pull/1659 where the dynamic imports with a `/* webpackChunkName */` comment no longer created chunks with the shared configs, when testing i also noticed that this is the case for the contacts app where the moment chunks are no longer built.

@skjnldsv Was there any specific reason this was explicitly set to commonjs?