### PR TITLE
Remove unnecessary plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 module.exports = {
 	plugins: [
-		'@babel/plugin-proposal-class-properties',
 		'@babel/plugin-syntax-dynamic-import',
-		'@babel/plugin-transform-modules-commonjs',
-		'@babel/plugin-transform-shorthand-properties',
 	],
 	presets: [
 		[


### PR DESCRIPTION
Remove unnecessary plugins for the following reasons

- [@babel/plugin-proposal-class-properties](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties) and [@babel/plugin-transform-shorthand-properties](https://babeljs.io/docs/en/babel-plugin-transform-shorthand-properties) are included in [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env)
- [@babel/plugin-transform-modules-commonjs](https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs) is handled by the `modules: 'auto'` option
![image](https://user-images.githubusercontent.com/14975046/124225246-658e2300-db07-11eb-8131-83ab1065e126.png)
- [@babel/preset-env `modules` option](https://babeljs.io/docs/en/babel-preset-env#modules)